### PR TITLE
If URLs don't include the vh_root, we can't split on it and reassemble

### DIFF
--- a/pleiades/rdf/common.py
+++ b/pleiades/rdf/common.py
@@ -178,7 +178,11 @@ class PleiadesGrapher(object):
         """We don't want the VH_ROOT ('/plone' or similar) in URLs
         we output.
         """
-        return urljoin(*context.absolute_url().split(self.vh_root))
+        context_url = context.absolute_url()
+        if self.vh_root in context_url:
+            return urljoin(*context_url.split(self.vh_root))
+        else:
+            return context_url
 
     def dcterms(self, context, g):
         """Return a set of tuples covering DC metadata"""

--- a/pleiades/rdf/common.py
+++ b/pleiades/rdf/common.py
@@ -179,7 +179,7 @@ class PleiadesGrapher(object):
         we output.
         """
         context_url = context.absolute_url()
-        if self.vh_root in context_url:
+        if self.vh_root and self.vh_root in context_url:
             return urljoin(*context_url.split(self.vh_root))
         else:
             return context_url


### PR DESCRIPTION
Fix for https://github.com/isawnyu/pleiades-gazetteer/issues/526